### PR TITLE
Correct pin value passed into analogRead, and change ADC prescaler to DVI8

### DIFF
--- a/src/AudioFrequencyMeter.cpp
+++ b/src/AudioFrequencyMeter.cpp
@@ -160,7 +160,7 @@ void AudioFrequencyMeter::ADCconfigure()
   while (ADCisSyncing())
     ;
 
-  ADC->CTRLB.bit.PRESCALER = ADC_CTRLB_PRESCALER_DIV4_Val;     // Divide Clock by 4 -> ~200kHz
+  ADC->CTRLB.bit.PRESCALER = ADC_CTRLB_PRESCALER_DIV8_Val;     // Divide Clock by 8 -> ~100kHz
   while (ADCisSyncing())
     ;
 

--- a/src/AudioFrequencyMeter.cpp
+++ b/src/AudioFrequencyMeter.cpp
@@ -69,7 +69,7 @@ void AudioFrequencyMeter::begin(uint32_t ulPin, uint32_t sampleRate)
 #endif
   __samplePin = ulPin;                              // Store ADC channel to sample
   __sampleRate = sampleRate;                        // Store sample rate value
-  analogRead(A0);                                   // To start setting-up the ADC
+  analogRead(ulPin);                                // To start setting-up the ADC
   ADCdisable();
   ADCconfigure();
   ADCenable();


### PR DESCRIPTION
Two improvements for now:

1) Correct pin value passed into `analogRead` A0 was passed in instead of `ulPin`

2) Bump now ADC prescaler to DIV8 instead of DIV4, reduces noise when reading value from ADC.
